### PR TITLE
Domains starting with numbers fix (#319)

### DIFF
--- a/src/linkify/core/parser.js
+++ b/src/linkify/core/parser.js
@@ -310,7 +310,8 @@ S_LOCALPART_DOT.on(localpartAccepting, S_LOCALPART);
 S_LOCALPART_AT
 .on(TLD, S_EMAIL_DOMAIN)
 .on(DOMAIN, S_EMAIL_DOMAIN)
-.on(LOCALHOST, S_EMAIL);
+.on(LOCALHOST, S_EMAIL)
+.on(NUM, S_EMAIL_DOMAIN);
 // States following `@` defined above
 
 let run = function (tokens) {

--- a/test/spec/linkify/core/parser-test.js
+++ b/test/spec/linkify/core/parser-test.js
@@ -121,6 +121,10 @@ var tests = [
 		[TEXT, MAILTOEMAIL, TEXT],
 		['Mailto is greedy ', 'mailto:localhost?subject=Hello%20World', '.']
 	], [
+		'Emails like: test@42.domain.com and test@42.abc.11.domain.com should be matched in its entirety.',
+		[TEXT, EMAIL, TEXT, EMAIL, TEXT],
+		['Emails like: ', 'test@42.domain.com', ' and ', 'test@42.abc.11.domain.com', ' should be matched in its entirety.']
+	], [
 		'Bu haritanın verileri Direniş İzleme Grubu\'nun yaptığı Türkiye İşçi Eylemleri haritası ile birleşebilir esasen. https://graphcommons.com/graphs/00af1cd8-5a67-40b1-86e5-32beae436f7c?show=Comments',
 		[TEXT, URL],
 		['Bu haritanın verileri Direniş İzleme Grubu\'nun yaptığı Türkiye İşçi Eylemleri haritası ile birleşebilir esasen. ', 'https://graphcommons.com/graphs/00af1cd8-5a67-40b1-86e5-32beae436f7c?show=Comments']


### PR DESCRIPTION
* Feat: Created parser test.

Created a parser test to determine if email domains that start with a number are matched correctly as email rather than url.

* Feat: Add "NUM" as accepted value for domain.

Closes: issue 279